### PR TITLE
font, color, accessory entity 생성 #3

### DIFF
--- a/src/main/java/com/endlesshorses/oot/domain/Accessory.java
+++ b/src/main/java/com/endlesshorses/oot/domain/Accessory.java
@@ -1,0 +1,22 @@
+package com.endlesshorses.oot.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Accessory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(unique = true, nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private Long price;
+    @Column(nullable = false)
+    private String imageUrl;
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String explanation;
+}

--- a/src/main/java/com/endlesshorses/oot/domain/Color.java
+++ b/src/main/java/com/endlesshorses/oot/domain/Color.java
@@ -1,0 +1,22 @@
+package com.endlesshorses.oot.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Color {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(unique = true, nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private Long red;
+    @Column(nullable = false)
+    private Long green;
+    @Column(nullable = false)
+    private Long blue;
+}

--- a/src/main/java/com/endlesshorses/oot/domain/Font.java
+++ b/src/main/java/com/endlesshorses/oot/domain/Font.java
@@ -1,0 +1,19 @@
+package com.endlesshorses.oot.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Font {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(unique = true, nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private Long price;
+    @Column(nullable = false)
+    private String imageUrl;
+}

--- a/src/main/java/com/endlesshorses/oot/domain/Font.java
+++ b/src/main/java/com/endlesshorses/oot/domain/Font.java
@@ -8,7 +8,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class Font {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(unique = true, nullable = false)
     private String name;


### PR DESCRIPTION
## Motivation
- #3 
- DB에 font 테이블 생성 필요 (id-BIGINT, name-VARCHAR, price-BIGINT, image_url-VARCHAR)
- DB에 color 테이블 생성 필요 (id-BIGINT, name-VARCHAR, red-BIGINT, green-BIGINT, blue-BIGINT)
- DB에 accessory 테이블 생성 필요 (id-BIGINT, name-VARCHAR, price-BIGINT, image_url-VARCHAR, explanation-TEXT)

## Problem Solving
- Spring Boot에서 Font, Color, Accessory Entity 생성

## To Reviewer
- Builder 없이 작성했습니당 더 나은 코드가 있다면 혹은 추천 사항이 있다면 알려주십숑~!💁‍♀️